### PR TITLE
Update project to the latest rust edition and dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 0.5.0 (July 17, 2020)
+- Update Rust to `edition = "2018"`.
+- Update dependencies on `syn`, `quote`, `darling` to their latest versions.
+- Drop `error-chain` dependency.
+
 ## 0.4.0 (May 14, 2018)
 - Update dependencies on `syn`, `quote`, `darling`, and `error-chain` to their latest versions.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## 0.5.0 (July 17, 2020)
+- Change minimum Rust version from 1.15 to 1.45
 - Update Rust to `edition = "2018"`.
 - Update dependencies on `syn`, `quote`, `darling` to their latest versions.
 - Drop `error-chain` dependency.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT/Apache-2.0"
 categories = ["development-tools", "rust-patterns"]
 description = "Rust macro to automatically generate conversions for newtype enums."
 readme = "README.md"
+edition = "2018"
 
 [badges]
 travis-ci = { repository = "TedDriggs/from_variants" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 travis-ci = { repository = "TedDriggs/from_variants" }
 
 [dependencies]
-from_variants_impl = { version = "=0.4.0", path = "from_variants_impl" }
+from_variants_impl = { version = "=0.5.0", path = "from_variants_impl" }
 
 [workspace]
 members = ["from_variants_impl"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "from_variants"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Ted Driggs <ted.driggs@outlook.com>"]
 repository = "https://github.com/TedDriggs/from_variants"
 documentation = "https://docs.rs/from_variants/0.4.0"

--- a/README.md
+++ b/README.md
@@ -3,13 +3,12 @@
 # Newtype Variant Conversions
 Rust macro crate to automatically generate conversions from variant types into the target enum.
 
-This crate requires Rust 1.15 or above to compile on stable.
+This crate requires Rust 1.45 or above to compile on stable.
 
 ## Examples
 
 ```rust
-#[macro_use]
-extern crate from_variants;
+use from_variants::FromVariants;
 
 #[derive(Debug, Clone, PartialEq, Eq, FromVariants)]
 pub enum Lorem {
@@ -25,13 +24,12 @@ fn main() {
 You can skip variants to avoid type collisions:
 
 ```rust
-#[macro_use]
-extern crate from_variants;
+use from_variants::FromVariants;
 
 #[derive(Debug, Clone, PartialEq, Eq, FromVariants)]
 pub enum Ipsum {
     Hello(String),
-    
+
     #[from_variants(skip)]
     Goodbye(String),
 }
@@ -44,5 +42,7 @@ fn main() {
 ## Features
 
 * **Variant opt-out**: To skip a variant, add `#[from_variants(skip)]` to that variant.
-* **Conversion support**: Use `#[from_variants(into)]` at the enum or variant level to get a generated conversion that accepts `Into<VariantType>`. In practice, this will only work with types defined in the same crate; otherwise you'll get conflicting impl errors.
+* **Conversion opt-in**: Use `#[from_variants(into)]` on an enum or variant to generate conversions
+  that will automatically convert - for example, accepting a `&str` for a `String` variant.
+  This must be used sparingly to avoid generating conflicting impls.
 * **no_std support**: Generated conversions do not depend on the standard library.

--- a/from_variants_impl/Cargo.toml
+++ b/from_variants_impl/Cargo.toml
@@ -12,13 +12,10 @@ edition = "2018"
 proc-macro = true
 
 [dependencies]
-darling = "0.5.0"
-quote = "0.5.2"
-syn = "0.13.10"
-
-[dependencies.error-chain]
-version = "0.11.0"
-default-features = false
+proc-macro2 = "1.0"
+darling = "0.10"
+quote = "1.0"
+syn = "1.0"
 
 [dev-dependencies]
-pretty_assertions = "0.1"
+pretty_assertions = "0.6"

--- a/from_variants_impl/Cargo.toml
+++ b/from_variants_impl/Cargo.toml
@@ -6,6 +6,7 @@ repository = "https://github.com/TedDriggs/from_variants"
 documentation = "https://docs.rs/from_variants/0.4.0"
 license = "MIT/Apache-2.0"
 description = "Internal helper crate for from_variants crate."
+edition = "2018"
 
 [lib]
 proc-macro = true

--- a/from_variants_impl/Cargo.toml
+++ b/from_variants_impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "from_variants_impl"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Ted Driggs <ted.driggs@outlook.com>"]
 repository = "https://github.com/TedDriggs/from_variants"
 documentation = "https://docs.rs/from_variants/0.4.0"

--- a/from_variants_impl/src/errors.rs
+++ b/from_variants_impl/src/errors.rs
@@ -1,7 +1,0 @@
-use error_chain::*;
-
-error_chain! {
-    foreign_links {
-        Darling(darling::Error);
-    }
-}

--- a/from_variants_impl/src/errors.rs
+++ b/from_variants_impl/src/errors.rs
@@ -1,4 +1,4 @@
-use darling;
+use error_chain::*;
 
 error_chain! {
     foreign_links {

--- a/from_variants_impl/src/from_impl.rs
+++ b/from_variants_impl/src/from_impl.rs
@@ -1,5 +1,5 @@
-use syn;
-use quote::{ToTokens, Tokens};
+use syn::parse_quote;
+use quote::{ToTokens, Tokens, *};
 
 /// The generic type parameter used when `into` conversions are requested.
 const INTO_GENERIC: &'static str = "INTO";
@@ -84,7 +84,8 @@ macro_rules! default_from_impl {
 
 #[cfg(test)]
 mod tests {
-    use syn;
+    use syn::parse_quote;
+    use quote::*;
     use super::FromImpl;
 
     #[test]

--- a/from_variants_impl/src/lib.rs
+++ b/from_variants_impl/src/lib.rs
@@ -1,30 +1,24 @@
-mod errors;
 mod from_impl;
 mod parser;
 
-mod prelude {
-    pub use crate::errors::{Error, ErrorKind, Result, ResultExt};
-}
-
 use darling::FromDeriveInput;
 use proc_macro::TokenStream;
-use quote::*; // TODO: upgrate quote version because it requires all macros in scope
-use prelude::*;
+use quote::quote;
+
+type Result<T> = std::result::Result<T, darling::Error>;
 
 #[doc(hidden)]
 #[allow(missing_docs)]
 #[proc_macro_derive(FromVariants, attributes(from_variants))]
 pub fn derive(input: TokenStream) -> TokenStream {
     let ast = syn::parse(input).expect("Couldn't parse item");
-    let result = build_converters(ast).unwrap().to_string();
-
-    result.parse().expect(&format!("Couldn't parse `{}` to tokens", result))
+    build_converters(ast).unwrap()
 }
 
-fn build_converters(ast: syn::DeriveInput) -> Result<quote::Tokens> {
+fn build_converters(ast: syn::DeriveInput) -> Result<TokenStream> {
     let context = parser::Container::from_derive_input(&ast).map_err(|e| e.flatten())?;
     let bodies = context.as_impls();
-    Ok(quote!(#(#bodies)*))
+    Ok(quote!(#(#bodies)*).into())
 }
 
 #[cfg(test)]

--- a/from_variants_impl/src/lib.rs
+++ b/from_variants_impl/src/lib.rs
@@ -1,33 +1,14 @@
-#![crate_type = "proc-macro"]
-
-#[macro_use]
-extern crate darling;
-
-#[macro_use]
-extern crate error_chain;
-
-#[cfg(test)]
-#[macro_use]
-extern crate pretty_assertions;
-
-extern crate proc_macro;
-
-#[macro_use]
-extern crate syn;
-
-#[macro_use]
-extern crate quote;
-
 mod errors;
 mod from_impl;
 mod parser;
 
 mod prelude {
-    pub use errors::{Error, ErrorKind, Result, ResultExt};
+    pub use crate::errors::{Error, ErrorKind, Result, ResultExt};
 }
 
 use darling::FromDeriveInput;
 use proc_macro::TokenStream;
+use quote::*; // TODO: upgrate quote version because it requires all macros in scope
 use prelude::*;
 
 #[doc(hidden)]

--- a/from_variants_impl/src/parser.rs
+++ b/from_variants_impl/src/parser.rs
@@ -1,8 +1,11 @@
-use darling::ast::{Data, Style, Fields};
-use darling::util::Ignored;
-use syn;
+use darling::{
+    ast::{Data, Style, Fields},
+    util::Ignored,
+    FromDeriveInput,
+    FromVariant,
+};
 
-use from_impl::FromImpl;
+use crate::from_impl::FromImpl;
 
 /// A parsing context which houses information read from the input until it
 /// can be used to construct the appropriate token stream.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,11 @@
 //! Rust macro crate to automatically generate conversions from variant types into the target enum.
 //!
-//! This crate requires Rust 1.15 or above to compile on stable.
+//! This crate requires Rust 1.45 or above to compile on stable.
 //!
 //! # Examples
 //!
 //! ```rust
-//! #[macro_use]
-//! extern crate from_variants;
+//! use from_variants::FromVariants;
 //!
 //! #[derive(Debug, Clone, PartialEq, Eq, FromVariants)]
 //! pub enum Lorem {
@@ -22,8 +21,7 @@
 //! You can skip variants to avoid type collisions:
 //!
 //! ```rust
-//! #[macro_use]
-//! extern crate from_variants;
+//! use from_variants::FromVariants;
 //!
 //! #[derive(Debug, Clone, PartialEq, Eq, FromVariants)]
 //! pub enum Ipsum {
@@ -43,11 +41,7 @@
 //! * **Conversion opt-in**: Use `#[from_variants(into)]` on an enum or variant to generate conversions
 //!   that will automatically convert - for example, accepting a `&str` for a `String` variant.
 //!   This must be used sparingly to avoid generating conflicting impls.
-extern crate core;
-
 #[allow(unused_imports)]
-#[macro_use]
-extern crate from_variants_impl;
 pub use from_variants_impl::*;
 
 #[doc(hidden)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@
 //! * **Conversion opt-in**: Use `#[from_variants(into)]` on an enum or variant to generate conversions
 //!   that will automatically convert - for example, accepting a `&str` for a `String` variant.
 //!   This must be used sparingly to avoid generating conflicting impls.
+//! * **no_std support**: Generated conversions do not depend on the standard library.
 #[allow(unused_imports)]
 pub use from_variants_impl::*;
 

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -1,5 +1,4 @@
-#[macro_use]
-extern crate from_variants;
+use from_variants::FromVariants;
 
 #[derive(Debug, PartialEq, Eq, FromVariants)]
 pub enum Demo<T> {

--- a/tests/no_std.rs
+++ b/tests/no_std.rs
@@ -1,8 +1,7 @@
 //! Compile and correctness test for using `core` instead of `std`.
 #![no_std]
 
-#[macro_use]
-extern crate from_variants;
+use from_variants::FromVariants;
 
 #[derive(Debug, PartialEq, Eq, FromVariants)]
 pub enum Lorem {


### PR DESCRIPTION
I had to remove error-chain since it looks like it
uses some deprecated apis (`Error::cause()`)
and I also had an error that `darling::Error` is not
thread-safe originated from error-chain.

Besides that I wonder how we can compare `proc_macro2::TokenStream` in `assert_eq!()`?
I just converted it `.to_string()` in `FromImpl` tests for now...

cc @TedDriggs 