### PR TITLE
Update `darling` dependency requirement to 0.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,16 @@
 # Change Log
 
+## 1.0.2 (February 4, 2023)
+
+- Update dependency on `darling` to its latest version (0.14).
+
 ## 1.0.1 (January 3, 2023)
 
 - Don't panic on tuple variants. [#9](https://github.com/TedDriggs/from_variants/issues/9)
 
 ## 1.0.0 (February 18, 2022)
 
-- Update dependency on `darling` to its latest version.
+- Update dependency on `darling` to its latest version (0.13).
 
 ## 0.6.0 (March 3, 2021)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "from_variants"
-version = "1.0.1"
+version = "1.0.2"
 authors = ["Ted Driggs <ted.driggs@outlook.com>"]
 repository = "https://github.com/TedDriggs/from_variants"
 license = "MIT/Apache-2.0"
@@ -10,7 +10,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-from_variants_impl = { version = "=1.0.1", path = "from_variants_impl" }
+from_variants_impl = { version = "=1.0.2", path = "from_variants_impl" }
 
 [workspace]
 members = ["from_variants_impl"]

--- a/from_variants_impl/Cargo.toml
+++ b/from_variants_impl/Cargo.toml
@@ -12,7 +12,7 @@ proc-macro = true
 
 [dependencies]
 proc-macro2 = "1.0"
-darling = "0.13"
+darling = "0.14"
 quote = "1.0"
 syn = "1.0"
 

--- a/from_variants_impl/Cargo.toml
+++ b/from_variants_impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "from_variants_impl"
-version = "1.0.1"
+version = "1.0.2"
 authors = ["Ted Driggs <ted.driggs@outlook.com>"]
 repository = "https://github.com/TedDriggs/from_variants"
 license = "MIT/Apache-2.0"


### PR DESCRIPTION
`darling` crate had a minor breaking change ([changelog](https://github.com/TedDriggs/darling/blob/master/CHANGELOG.md#v0140-april-13-2022)), which doesn't affect this crate.

I'd like to bump the version of `darling` to prevent compiling both `0.13` and `0.14` versions of `darling` in my [project](https://github.com/Veetaha/snowpity/blob/6c253d66467951bfe99668bdab12098dff1d1f58/Cargo.toml#L31)